### PR TITLE
Don't invert the polarity of the GPIO pins by default

### DIFF
--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -57,9 +57,11 @@ class MCP23008(MCP230XX):
 
     def __init__(self, i2c, address=_MCP23008_ADDRESS):
         super().__init__(i2c, address)
-        # Reset device state to all pins as inputs (safest option).
-        self._write_u8(_MCP23008_IODIR, 0xFF)
 
+        # Reset to all inputs with no pull-ups and no inverted polarity.
+        self.iodir = 0xFF
+        self.gppu  = 0x00
+        self._write_u8(_MCP23008_IPOL, 0x00)
 
     @property
     def gpio(self):

--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -51,8 +51,7 @@ class MCP23008(MCP230XX):
     def __init__(self, i2c, address=_MCP23008_ADDRESS):
         super().__init__(i2c, address)
         # Reset device state to all pins as inputs (safest option).
-        with self._device as device:
-            self._write_u8(_MCP23008_IODIR, 0xFF)
+        self._write_u8(_MCP23008_IODIR, 0xFF)
 
 
     @property

--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -52,9 +52,8 @@ class MCP23008(MCP230XX):
         super().__init__(i2c, address)
         # Reset device state to all pins as inputs (safest option).
         with self._device as device:
-            # Write to MCP23008_IODIR register 0xFF followed by 9 zeros
-            # for defaults of other registers.
-            device.write('\x00\xFF\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+            self._write_u8(_MCP23008_IODIR, 0xFF)
+
 
     @property
     def gpio(self):

--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -39,7 +39,14 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MCP230xx.git"
 # pylint: disable=bad-whitespace
 _MCP23008_ADDRESS       = const(0x20)
 _MCP23008_IODIR         = const(0x00)
+_MCP23008_IPOL          = const(0x01)
+_MCP23008_GPINTEN       = const(0x02)
+_MCP23008_DEFVAL        = const(0x03)
+_MCP23008_INTCON        = const(0x04)
+_MCP23008_IOCON         = const(0x05)
 _MCP23008_GPPU          = const(0x06)
+_MCP23008_INTF          = const(0x07)
+_MCP23008_INTCAP        = const(0x08)
 _MCP23008_GPIO          = const(0x09)
 
 


### PR DESCRIPTION
This PR changes the init behavior of the MCP23008 so only the `IODIR` register is set for input and leaves the other registers alone. By writing `\xFF` to the second, `IPOL`,  register it was inverting the polarity of the GPIO ports.