### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_mcp230xx/digital_inout.py
+++ b/adafruit_mcp230xx/digital_inout.py
@@ -112,9 +112,9 @@ class DigitalInOut:
         try:
             if _get_bit(self._mcp.gppu, self._pin):
                 return digitalio.Pull.UP
-        except AttributeError as e:
+        except AttributeError as error:
             # MCP23016 doesn't have a `gppu` register.
-            raise ValueError("Pull-up/pull-down resistors not supported.") from e
+            raise ValueError("Pull-up/pull-down resistors not supported.") from error
         return None
 
     @pull.setter
@@ -128,6 +128,6 @@ class DigitalInOut:
                 raise ValueError("Pull-down resistors are not supported!")
             else:
                 raise ValueError("Expected UP, DOWN, or None for pull state!")
-        except AttributeError as e:
+        except AttributeError as error:
             # MCP23016 doesn't have a `gppu` register.
-            raise ValueError("Pull-up/pull-down resistors not supported.") from e
+            raise ValueError("Pull-up/pull-down resistors not supported.") from error

--- a/adafruit_mcp230xx/digital_inout.py
+++ b/adafruit_mcp230xx/digital_inout.py
@@ -112,9 +112,9 @@ class DigitalInOut:
         try:
             if _get_bit(self._mcp.gppu, self._pin):
                 return digitalio.Pull.UP
-        except AttributeError:
+        except AttributeError as e:
             # MCP23016 doesn't have a `gppu` register.
-            raise ValueError("Pull-up/pull-down resistors not supported.")
+            raise ValueError("Pull-up/pull-down resistors not supported.") from e
         return None
 
     @pull.setter
@@ -128,6 +128,6 @@ class DigitalInOut:
                 raise ValueError("Pull-down resistors are not supported!")
             else:
                 raise ValueError("Expected UP, DOWN, or None for pull state!")
-        except AttributeError:
+        except AttributeError as e:
             # MCP23016 doesn't have a `gppu` register.
-            raise ValueError("Pull-up/pull-down resistors not supported.")
+            raise ValueError("Pull-up/pull-down resistors not supported.") from e

--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -19,7 +19,6 @@ from .digital_inout import DigitalInOut
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MCP230xx.git"
 
-# pylint: disable=bad-whitespace
 _MCP23008_ADDRESS = const(0x20)
 _MCP23008_IODIR = const(0x00)
 _MCP23008_IPOL = const(0x01)

--- a/adafruit_mcp230xx/mcp23016.py
+++ b/adafruit_mcp230xx/mcp23016.py
@@ -27,7 +27,6 @@ from .digital_inout import DigitalInOut
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MCP230xx.git"
 
-# pylint: disable=bad-whitespace
 _MCP23016_ADDRESS = const(0x20)
 _MCP23016_GPIO0 = const(0x00)
 _MCP23016_GPIO1 = const(0x01)

--- a/adafruit_mcp230xx/mcp23017.py
+++ b/adafruit_mcp230xx/mcp23017.py
@@ -19,7 +19,6 @@ from .digital_inout import DigitalInOut
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MCP230xx.git"
 
-# pylint: disable=bad-whitespace
 _MCP23017_ADDRESS = const(0x20)
 _MCP23017_IODIRA = const(0x00)
 _MCP23017_IODIRB = const(0x01)


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.