### PR TITLE
Added reset keyword

### DIFF
--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -37,13 +37,14 @@ class MCP23008(MCP230XX):
     at the specified I2C address.
     """
 
-    def __init__(self, i2c, address=_MCP23008_ADDRESS):
+    def __init__(self, i2c, address=_MCP23008_ADDRESS, reset=True):
         super().__init__(i2c, address)
 
-        # Reset to all inputs with no pull-ups and no inverted polarity.
-        self.iodir = 0xFF
-        self.gppu = 0x00
-        self._write_u8(_MCP23008_IPOL, 0x00)
+        if reset:
+            # Reset to all inputs with no pull-ups and no inverted polarity.
+            self.iodir = 0xFF
+            self.gppu = 0x00
+            self._write_u8(_MCP23008_IPOL, 0x00)
 
     @property
     def gpio(self):

--- a/adafruit_mcp230xx/mcp23016.py
+++ b/adafruit_mcp230xx/mcp23016.py
@@ -45,12 +45,13 @@ class MCP23016(MCP230XX):
     at the specified I2C address.
     """
 
-    def __init__(self, i2c, address=_MCP23016_ADDRESS):
+    def __init__(self, i2c, address=_MCP23016_ADDRESS, reset=True):
         super().__init__(i2c, address)
 
-        # Reset to all inputs and no inverted polarity.
-        self.iodir = 0xFFFF
-        self._write_u16le(_MCP23016_IPOL0, 0x0000)
+        if reset:
+            # Reset to all inputs and no inverted polarity.
+            self.iodir = 0xFFFF
+            self._write_u16le(_MCP23016_IPOL0, 0x0000)
 
     @property
     def gpio(self):

--- a/adafruit_mcp230xx/mcp23017.py
+++ b/adafruit_mcp230xx/mcp23017.py
@@ -45,13 +45,14 @@ class MCP23017(MCP230XX):
     at the specified I2C address.
     """
 
-    def __init__(self, i2c, address=_MCP23017_ADDRESS):
+    def __init__(self, i2c, address=_MCP23017_ADDRESS, reset=True):
         super().__init__(i2c, address)
-        # Reset to all inputs with no pull-ups and no inverted polarity.
-        self.iodir = 0xFFFF
-        self.gppu = 0x0000
-        self.iocon = 0x4  # turn on IRQ Pins as open drain
-        self._write_u16le(_MCP23017_IPOLA, 0x0000)
+        if reset:
+            # Reset to all inputs with no pull-ups and no inverted polarity.
+            self.iodir = 0xFFFF
+            self.gppu = 0x0000
+            self.iocon = 0x4  # turn on IRQ Pins as open drain
+            self._write_u16le(_MCP23017_IPOLA, 0x0000)
 
     @property
     def gpio(self):


### PR DESCRIPTION
Adds a reset keyword that allows you not to reset the i2c settings when initializing the functions.

Tested **only** on an MCP23017