### PR TITLE
Replace assert with if statement (Fixes #32)

### DIFF
--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -85,5 +85,6 @@ class MCP23008(MCP230XX):
         """Convenience function to create an instance of the DigitalInOut class
         pointing at the specified pin of this MCP23008 device.
         """
-        assert 0 <= pin <= 7
+        if not 0 <= pin <= 7:
+            raise ValueError("Pin number must be 0-7.")
         return DigitalInOut(pin, self)

--- a/adafruit_mcp230xx/mcp23016.py
+++ b/adafruit_mcp230xx/mcp23016.py
@@ -126,7 +126,8 @@ class MCP23016(MCP230XX):
         """Convenience function to create an instance of the DigitalInOut class
         pointing at the specified pin of this MCP23016 device.
         """
-        assert 0 <= pin <= 15
+        if not 0 <= pin <= 15:
+            raise ValueError("Pin number must be 0-15.")
         return DigitalInOut(pin, self)
 
     def clear_inta(self):

--- a/adafruit_mcp230xx/mcp23017.py
+++ b/adafruit_mcp230xx/mcp23017.py
@@ -163,7 +163,8 @@ class MCP23017(MCP230XX):
         """Convenience function to create an instance of the DigitalInOut class
         pointing at the specified pin of this MCP23017 device.
         """
-        assert 0 <= pin <= 15
+        if not 0 <= pin <= 15:
+            raise ValueError("Pin number must be 0-15.")
         return DigitalInOut(pin, self)
 
     @property


### PR DESCRIPTION
Searched all the files in this library for `assert` statements and found one in each of mcp23008.py, mcp23016.py and mcp23017.py.  Replaced `assert` statement with `if` statement raising a `ValueError` if the pin number passed is out-of-bounds (based on the value ranges in the original assert statements) and returning a more user-friendly error message indicating the correct range of pin values.

Happy to make any other changes necessary, just let me know if I need to do anything differently.