### PR TITLE
Add interrupt handling properties and methods to MCP23008 class

### DIFF
--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -185,7 +185,7 @@ class MCP23008(MCP230XX):
         flags = [pin for pin in range(8) if intf & (1 << pin)]
         return flags
 
-     @property
+    @property
     def int_cap(self) -> List[int]:
         """Returns a list with the pin values at time of interrupt
         pins 0-7

--- a/adafruit_mcp230xx/mcp23008.py
+++ b/adafruit_mcp230xx/mcp23008.py
@@ -27,7 +27,7 @@ from .digital_inout import DigitalInOut
 from .mcp230xx import MCP230XX
 
 try:
-    import typing
+    from typing import List
 
     from busio import I2C
 except ImportError:
@@ -105,3 +105,94 @@ class MCP23008(MCP230XX):
         if not 0 <= pin <= 7:
             raise ValueError("Pin number must be 0-7.")
         return DigitalInOut(pin, self)
+
+    @property
+    def ipol(self) -> int:
+        """The raw IPOL output register.  Each bit represents the
+        polarity value of the associated pin (0 = normal, 1 = inverted), assuming that
+        pin has been configured as an input previously.
+        """
+        return self._read_u8(_MCP23008_IPOL)
+
+    @ipol.setter
+    def ipol(self, val: int) -> None:
+        self._write_u8(_MCP23008_IPOL, val)
+
+    @property
+    def interrupt_configuration(self) -> int:
+        """The raw INTCON interrupt control register. The INTCON register
+        controls how the associated pin value is compared for the
+        interrupt-on-change feature. If  a  bit  is  set,  the  corresponding
+        I/O  pin  is  compared against the associated bit in the DEFVAL
+        register. If a bit value is clear, the corresponding I/O pin is
+        compared against the previous value.
+        """
+        return self._read_u8(_MCP23008_INTCON)
+
+    @interrupt_configuration.setter
+    def interrupt_configuration(self, val: int) -> None:
+        self._write_u8(_MCP23008_INTCON, val)
+
+    @property
+    def interrupt_enable(self) -> int:
+        """The raw GPINTEN interrupt control register. The GPINTEN register
+        controls the interrupt-on-change feature for each pin. If a bit is
+        set, the corresponding pin is enabled for interrupt-on-change.
+        The DEFVAL and INTCON registers must also be configured if any pins
+        are enabled for interrupt-on-change.
+        """
+        return self._read_u8(_MCP23008_GPINTEN)
+
+    @interrupt_enable.setter
+    def interrupt_enable(self, val: int) -> None:
+        self._write_u8(_MCP23008_GPINTEN, val)
+
+    @property
+    def default_value(self) -> int:
+        """The raw DEFVAL interrupt control register. The default comparison
+        value is configured in the DEFVAL register. If enabled (via GPINTEN
+        and INTCON) to compare against the DEFVAL register, an opposite value
+        on the associated pin will cause an interrupt to occur.
+        """
+        return self._read_u8(_MCP23008_DEFVAL)
+
+    @default_value.setter
+    def default_value(self, val: int) -> None:
+        self._write_u8(_MCP23008_DEFVAL, val)
+
+    @property
+    def io_control(self) -> int:
+        """The raw IOCON configuration register. Bit 1 controls interrupt
+        polarity (1 = active-high, 0 = active-low). Bit 2 is whether irq pin
+        is open drain (1 = open drain, 0 = push-pull). Bit 3 is unused.
+        Bit 4 is whether SDA slew rate is enabled (1 = yes). Bit 5 is if I2C
+        address pointer auto-increments (1 = no). Bit 6 is unused. Bit 7 is
+        unused.
+        """
+        return self._read_u8(_MCP23008_IOCON)
+
+    @io_control.setter
+    def io_control(self, val: int) -> None:
+        val &= ~0x80
+        self._write_u8(_MCP23008_IOCON, val)
+
+    @property
+    def int_flag(self) -> List[int]:
+        """Returns a list with the pin numbers that caused an interrupt
+        pins 0-7
+        """
+        intf = self._read_u8(_MCP23008_INTF)
+        flags = [pin for pin in range(8) if intf & (1 << pin)]
+        return flags
+
+     @property
+    def int_cap(self) -> List[int]:
+        """Returns a list with the pin values at time of interrupt
+        pins 0-7
+        """
+        intcap = self._read_u8(_MCP23008_INTCAP)
+        return [(intcap >> pin) & 1 for pin in range(8)]
+
+    def clear_ints(self) -> None:
+        """Clears interrupts by reading INTCAP."""
+        self._read_u8(_MCP23008_INTCAP)

--- a/examples/mcp230xx_interrupt_example.py
+++ b/examples/mcp230xx_interrupt_example.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 James Douglas
+#
+# SPDX-License-Identifier: MIT
+#
+# Demo of using the interrupt configuration registers of the MCP2300xx
+# and the functionality of the interrupt pin.
+#
+# Example assumes the interrupt pin of the MCP2300xx is connected to
+# GP15 on a Raspberry Pi Pico or similar board.
+#
+# Author: James Douglas
+
+import asyncio
+import board
+import busio
+import digitalio
+
+from adafruit_mcp230xx.mcp23008 import MCP23008
+# from adafruit_mcp230xx.mcp23017 import MCP23017
+
+# I2C setup
+i2c = busio.I2C(board.GP5, board.GP4)
+
+# Chip setup
+mcp = MCP23008(i2c)  # MCP23008
+# mcp = MCP23017(i2c)  # MCP23017
+# mcp = MCP23017(i2c, address=0x21)  # e.g. MCP23017 w/ A0 set
+
+# List of all the pins (e.g. 0-7 for MCP23008, 0-15 for MCP23017)
+pins = []
+for pin in range(0, 8):
+    pins.append(mcp.get_pin(pin))
+
+# Set all the pins to input w/ Pull-Up
+for pin in pins:
+    pin.direction = digitalio.Direction.INPUT
+    pin.pull = digitalio.Pull.UP
+
+
+# Setup Initial Interrupt config on MCP230xx
+mcp.interrupt_enable = 0xFF # Enable Interrupts in all pins - 0xFFFF for MCP23017
+mcp.interrupt_configuration = 0x00 # interrupt on any change - 0x0000 for MCP23017
+mcp.io_control = 0x04 # Open-drain INT pin
+mcp.clear_ints()
+
+# Setup interrupt listener on Pico
+int_listener = digitalio.DigitalInOut(board.GP15)
+int_listener.direction = digitalio.Direction.INPUT
+int_listener.pull = digitalio.Pull.UP
+
+async def monitor_interrupts():
+    """
+    Loop that monitors the interrupt pin and prints out the interrupt
+    flags and values when an interrupt occurs.
+    """
+    print("Listening for MCP200xx interrupts...")
+
+    while True:
+        # The interrupt pin is open-drain and pulled UP
+        # so it goes LOW on interrupt
+        if not int_listener.value:
+            # Identify which pin(s) caused the interrupt
+            flags = mcp.int_flag
+            # Capture the state of all pins at the time of the interrupt
+            # Reading INTCAP also clears the interrupt flags
+            caps = mcp.int_cap
+
+            # Alternatively, you could ignore INTCAP and
+            # just read the current pin states from GPIO
+
+            if flags:
+                print("\n--- Interrupt Detected ---")
+                for pin in flags:
+                    print(f"Pin {pin} triggered the interrupt. Captured value: {caps[pin]}")
+
+            # We don't need to manually clear the interrupt flags,
+            # reading the int_cap register already does that.
+            # However, if you want to clear any pending interrupts without
+            # reading the captured values (e.g. you are reading GPIO
+            # directly), you can call mcp.clear_ints()
+
+            # Add a small delay to act as a software debounce
+            await asyncio.sleep(0.2)
+
+        # Yield control back to the event loop
+        await asyncio.sleep(0.01)
+
+async def main():
+    """
+    Main async function to run the interrupt monitoring loop.
+
+    Could also include other async tasks here if needed instead of
+    just awaiting monitor_interrupts()
+    """
+    await monitor_interrupts()
+
+# Run the async loop
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/mcp230xx_interrupt_example.py
+++ b/examples/mcp230xx_interrupt_example.py
@@ -11,11 +11,13 @@
 # Author: James Douglas
 
 import asyncio
+
 import board
 import busio
 import digitalio
 
 from adafruit_mcp230xx.mcp23008 import MCP23008
+
 # from adafruit_mcp230xx.mcp23017 import MCP23017
 
 # I2C setup
@@ -38,15 +40,16 @@ for pin in pins:
 
 
 # Setup Initial Interrupt config on MCP230xx
-mcp.interrupt_enable = 0xFF # Enable Interrupts in all pins - 0xFFFF for MCP23017
-mcp.interrupt_configuration = 0x00 # interrupt on any change - 0x0000 for MCP23017
-mcp.io_control = 0x04 # Open-drain INT pin
+mcp.interrupt_enable = 0xFF  # Enable Interrupts in all pins - 0xFFFF for MCP23017
+mcp.interrupt_configuration = 0x00  # interrupt on any change - 0x0000 for MCP23017
+mcp.io_control = 0x04  # Open-drain INT pin
 mcp.clear_ints()
 
 # Setup interrupt listener on Pico
 int_listener = digitalio.DigitalInOut(board.GP15)
 int_listener.direction = digitalio.Direction.INPUT
 int_listener.pull = digitalio.Pull.UP
+
 
 async def monitor_interrupts():
     """
@@ -85,6 +88,7 @@ async def monitor_interrupts():
         # Yield control back to the event loop
         await asyncio.sleep(0.01)
 
+
 async def main():
     """
     Main async function to run the interrupt monitoring loop.
@@ -93,6 +97,7 @@ async def main():
     just awaiting monitor_interrupts()
     """
     await monitor_interrupts()
+
 
 # Run the async loop
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds new interrupt and configuration register properties to the `MCP23008` class (based on the existing `MCP23017` class), enabling more fine-grained control and monitoring of the device's interrupt and input/output behavior. These additions allow users to access and modify the registers related to pin polarity, interrupt configuration, and IO control, as well as easily determine which pins triggered interrupts and their values at the time.

New interrupt and configuration register properties:

* Added `ipol` property with getter and setter for accessing and modifying the pin polarity register.
* Added `interrupt_configuration`, `interrupt_enable`, and `default_value` properties with getters and setters for configuring interrupt behavior and default comparison values.
* Added `io_control` property with getter and setter for configuring IO control register settings such as interrupt polarity and address pointer auto-increment.

Interrupt monitoring enhancements:

* Added `int_flag` property to return a list of pin numbers that caused an interrupt, and `int_cap` property to return pin values at the time of interrupt.
* Added `clear_ints` method to clear interrupts by reading the INTCAP register.

Type hint improvements:

* Changed import of `typing` to import `List` directly for improved type hint clarity.

Tested on Raspberry Pi Pico and Raspberry Pi Pico 2 with MCP23008 hardware using Pico GPIO trigger and int monitoring via [this test code](https://github.com/jimmydoh/test-mcp23008-interrupts)